### PR TITLE
Revert custom script from ASU YT.

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -171,5 +171,4 @@
 % if settings.FEATURES.get('ENABLE_COOKIE_CONSENT', False):
   <%include file="widgets/cookie-consent.html" />
 % endif
-<script src="https://youngthinker.org/sites/default/files/dictionary/dictionary_min.js"></script>
 


### PR DESCRIPTION
Скрипт ломает энролл.

> Как написано проблема в наличие следующего скрипта в коде футера
> 
> <script src="https://youngthinker.org/sites/default/files/dictionary/dictionary_min.js" ></script>
> Разобравшись с скриптом обнаружил что следующая команда в js файле
> 
>  document.getElementsByTagName("head")[0].appendChild(script);
> Ломает процесс CSRF авторизации во всех формах при отправлении асинхронного POST запроса с использованием jquery метода $.ajax(). Причина поломки форм отсутсвие X-CSRFToken токена в заголовке запроса.
> 
> Для работы функционала платформы необходимо поправить данный скрипт удалив данную строчку.
> 

https://youtrack.raccoongang.com/issue/ASUYT-29