### PR TITLE
[E4H] Show effort string from site setting

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -6,6 +6,7 @@ from courseware.courses import get_course_about_section
 from django.conf import settings
 from edxmako.shortcuts import marketing_link
 from openedx.core.lib.courses import course_image_url
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 %>
 
 <%inherit file="../main.html" />
@@ -260,14 +261,15 @@ from openedx.core.lib.courses import course_image_url
             </li>
             % endif
           <%
-              course_about_section_effort = (
-                  get_course_about_section(request, course, "effort")
-                  and
-                  get_course_about_section(request, course, "effort")!=u'\n\n\n\n'
-              )
+              estimation_effort_string = configuration_helpers.get_value('estimation_effort_string')
+              course_effort = get_course_about_section(request, course, "effort")
+              course_about_section_effort = (estimation_effort_string or (course_effort and course_effort!=u'\n\n\n\n'))
           %>
           % if (course_about_section_effort):
-            <li class="important-dates-item"><span class="icon fa fa-pencil" aria-hidden="true"></span><p class="important-dates-item-title">${_("Estimated Effort")}</p><span class="important-dates-item-text effort">${get_course_about_section(request, course, "effort")}</span></li>
+            <%
+              estimation_effort_string = estimation_effort_string if estimation_effort_string else course_effort
+            %>
+            <li class="important-dates-item"><span class="icon fa fa-pencil" aria-hidden="true"></span><p class="important-dates-item-title">${_("Estimated Effort")}</p><span class="important-dates-item-text effort">${estimation_effort_string}</span></li>
           % endif
 
           ##<li class="important-dates-item"><span class="icon fa fa-clock-o" aria-hidden="true"></span><p class="important-dates-item-title">${_('Course Length')}</p><span class="important-dates-item-text course-length">${_('{number} weeks').format(number=15)}</span></li>


### PR DESCRIPTION
*Description:* The customer wants that each course to say either "5-10 hours depending on English proficiency" OR "05:00 - 10:00" 
I added 'estimation_effort_string' setting to the admin page (/admin/site_configuration/siteconfiguration/) and show it in the course about page.

*Task:* https://youtrack.raccoongang.com/issue/EFH-18

*Setting:*
In admin page in siteconfiguration: /admin/site_configuration/siteconfiguration/
You shoud add nex setting for site configuration:
```
{
...

  "estimation_effort_string":"5:00 - 10:00"
...
}
```