### PR TITLE
[EFH] Use ESTIMATION_EFFORT_STRING setting to show effort string

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -262,7 +262,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % endif
 
           <%
-              estimation_effort_string = settings.ESTIMATION_EFFORT_STRING
+              estimation_effort_string = (
+                  settings.ESTIMATION_EFFORT_STRING if hasattr(settings, 'ESTIMATION_EFFORT_STRING') else ''
+              )
               course_effort = get_course_about_section(request, course, "effort")
               course_about_section_effort = (estimation_effort_string or (course_effort and course_effort!=u'\n\n\n\n'))
           %>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -260,8 +260,9 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
                   % endif
             </li>
             % endif
+
           <%
-              estimation_effort_string = configuration_helpers.get_value('estimation_effort_string')
+              estimation_effort_string = settings.ESTIMATION_EFFORT_STRING
               course_effort = get_course_about_section(request, course, "effort")
               course_about_section_effort = (estimation_effort_string or (course_effort and course_effort!=u'\n\n\n\n'))
           %>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -262,9 +262,7 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
             % endif
 
           <%
-              estimation_effort_string = (
-                  settings.ESTIMATION_EFFORT_STRING if hasattr(settings, 'ESTIMATION_EFFORT_STRING') else ''
-              )
+              estimation_effort_string = getattr(settings, 'ESTIMATION_EFFORT_STRING', '')
               course_effort = get_course_about_section(request, course, "effort")
               course_about_section_effort = (estimation_effort_string or (course_effort and course_effort!=u'\n\n\n\n'))
           %>


### PR DESCRIPTION
**Description:** Use ESTIMATION_EFFORT_STRING setting to show effort string in the about course page.
**Tasks:** https://youtrack.raccoongang.com/issue/EFH-19

*Requirements*
This code is using the setting 'ESTIMATION_EFFORT_STRING' in the Django settings.
Please add the setting 'ESTIMATION_EFFORT_STRING' to the Django setting.
