### PR TITLE
Bugfix - FM-33 Sign-in page: Change the registration button text and …

### DIFF
--- a/lms/templates/register-form.html
+++ b/lms/templates/register-form.html
@@ -236,9 +236,9 @@ from student.models import UserProfile
   <ol class="list-input">
     <li class="field-group">
 
-      % if REGISTRATION_EXTRA_FIELDS['terms_of_service'] != 'hidden':
+      % if REGISTRATION_EXTRA_FIELDS.get('terms_of_service', 'required') != 'hidden':
           % if has_extauth_info is UNDEFINED or ask_for_tos :
-          <div class="field ${REGISTRATION_EXTRA_FIELDS['terms_of_service']} checkbox" id="field-tos">
+          <div class="field ${REGISTRATION_EXTRA_FIELDS.get('terms_of_service', 'required')} checkbox" id="field-tos">
             <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
             <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
               link_start='<a href="{url}" class="new-vp" tabindex="-1">'.format(url=marketing_link('TOS')),


### PR DESCRIPTION
BUGFIX: [FM-33](
https://youtrack.raccoongang.com/issue/FM-33) - `Sign-in page: Change the registration button text and move the text`

- processed case when there is no `terms_of_service` key in the `REGISTRATION_EXTRA_FIELDS` setting