### PR TITLE
[ALU] Add `Peer Groups` navigation link to Student

### DIFF
--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -44,6 +44,9 @@ from django.utils.translation import ugettext as _
         <a href="${reverse('widget:index-student')}">${_("Personalised Learning")}</a>
       </li>
       % endif
+      <li class="item nav-global-01">
+        <a href="${reverse('pcitool:index-student')}">${_("Peer Groups")}</a>
+      </li>
     % endif
 
     %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:


### PR DESCRIPTION
[ALUE-269](https://youtrack.raccoongang.com/issue/ALUE-269)

### Added:

- extra nav link `Peer Groups`;

Note: additionally the `COURSES_ARE_BROWSABLE` must be set to `False` for LMS.