### PR TITLE
[DRAFT, WIP]ACT-20 On the Honor certificate, the username is displayed instead of…

### DIFF
--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -16,7 +16,7 @@ course_mode_class = course_mode if course_mode else ''
             <strong class="general-text">${_("This certificate is proudly presented to")}</strong>
         </div>
         <div class="inner">
-            <strong class="user-name">${accomplishment_copy_username}</strong>
+            <strong class="user-name">${accomplishment_copy_name}</strong>
             <p class="certificate-text">${accomplishment_copy_description_full}</p>
             <strong class="course-name">${accomplishment_copy_course_org} ${course_number}: ${accomplishment_copy_course_name}</strong>
         </div>


### PR DESCRIPTION
[ACT-20](
https://youtrack.raccoongang.com/issue/ACT-20) - `On the Honor certificate, the username is displayed instead of the full name.`

 - replaced `accomplishment_copy_username` to `accomplishment_copy_name`