### PR TITLE
ACT-16 If a staff sets the Course Short Description in CMS, the descr…

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -118,9 +118,12 @@ from six import string_types
           <div class="heading-group">
             <h1>
               ${course.display_name_with_default_escaped}
+              <button type="button">${course.display_org_with_default | h}</button>
             </h1>
-            <br />
-            <span>${course.display_org_with_default | h}</span>
+            <br/>
+            <h3>
+              ${get_course_about_section(request, course, 'short_description')}
+            </h3>
           </div>
 
           <div class="main-cta">


### PR DESCRIPTION
[ACT-16](https://youtrack.raccoongang.com/issue/ACT-16) - `If a staff sets the Course Short Description in CMS, the description is not displayed on the About page in LMS.`

- Added short description to the CourseAbout page