### PR TITLE
Arrow 66/create categories on the main page 

### DIFF
--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -17,7 +17,7 @@
             </li>
             % endfor
         % else:
-            % for course in courses[:settings.HOMEPAGE_COURSE_MAX]:
+            % for course in courses:
             <li class="courses-listing-item">
                 <%include file="course.html" args="course=course" />
             </li>
@@ -25,20 +25,6 @@
         % endif
         </ul>
       </section>
-
-      <div class="courses-more">
-
-        ## in case there are courses that are not shown on the homepage, a 'View all Courses' link should appear
-        % if settings.HOMEPAGE_COURSE_MAX and len(courses) > settings.HOMEPAGE_COURSE_MAX:
-        <a class="btn courses-more-cta" href="${marketing_link('COURSES')}"> ${_("View all Courses")} </a>
-        % endif
-
-        % if len(courses) > 8:
-        <a class="btn show-more">Show more courses</a>
-        <i class="fa fa-spinner fa-spin"></i>
-        % endif
-
-      </div>
 
     % endif
 


### PR DESCRIPTION
Arrow 66/create categories on the main page 
deleted limit 'HOMEPAGE_COURSE_MAX' on the main page
this issue [ARROW-84](https://youtrack.raccoongang.com/issue/ARROW-84) is a part of arrow 66
 