### PR TITLE
[LSE-25] fix empty space on course about page for IE

### DIFF
--- a/lms/static/sass/base/_override.scss
+++ b/lms/static/sass/base/_override.scss
@@ -3635,6 +3635,7 @@ body .account-settings-sections .section .account-settings-section-body .u-field
 
     #content {
         flex: 1 1 auto;
+        overflow: hidden;
     }
 
     .wrapper-footer {


### PR DESCRIPTION
**Description:** fix empty space on course about page for IE
**Youtrack:** https://youtrack.raccoongang.com/issue/LSE-25