### PR TITLE
[4A-32] Fix for courses list

### DIFF
--- a/lms/templates/course.html
+++ b/lms/templates/course.html
@@ -6,9 +6,6 @@ from django.core.urlresolvers import reverse
 %>
 <%page args="course" expression_filter="h"/>
 <article class="course" id="${course.id}" role="region" aria-label="${course.display_name_with_default}">
-
-    ${xml_header | n}
-
     <a href="${reverse('about_course', args=[course.id.to_deprecated_string()])}">
         <header class="course-image">
             <div class="cover-image">


### PR DESCRIPTION
https://youtrack.raccoongang.com/issue/4A-32

In previous commits on this task was found a bug that shows the xml header in every course on courses list page.