### PR TITLE
SKILLONOMY-95 (p.68): Add 'Copy Referral Link' functionality

### DIFF
--- a/lms/static/sass/base/_override.scss
+++ b/lms/static/sass/base/_override.scss
@@ -1708,6 +1708,7 @@ body .login .form-actions button[type="submit"] {
 .login-register .login-provider,
 body .dashboard .my-courses .course .details .enter-course.archived,
 .account-settings-sections .section .account-settings-section-body .u-field .field .u-field-link,
+.referral-btn-wrapper .referral-btn.last-accessed-link,
 .dashboard .my-courses .course .details .enter-course {
     white-space: nowrap;
     background: $theme-btn-white-bg;
@@ -1728,6 +1729,20 @@ body .dashboard .my-courses .course .details .enter-course.archived,
         border-color: $theme-btn-white-bg-hover;
     }
 }
+
+.referral-btn-wrapper {
+    display: flex;
+    justify-content: flex-start;
+    align-content: center;
+    margin-bottom: 1rem;
+    padding-left: 1.25rem;
+
+    @media (min-width: 1200px) {
+        padding-left: initial;
+    }
+}
+
+
 body .discussion-module .btn {
     white-space: nowrap;
     background: $theme-btn-white-bg;

--- a/lms/static/sass/base/_override.scss
+++ b/lms/static/sass/base/_override.scss
@@ -1730,6 +1730,14 @@ body .dashboard .my-courses .course .details .enter-course.archived,
     }
 }
 
+.referral-btn-wrapper .referral-btn.last-accessed-link {
+    box-sizing: border-box;
+    letter-spacing: 0;
+    border-radius: 3px;
+    padding: 8px 20px;
+    text-align: center;
+}
+
 .referral-btn-wrapper {
     display: flex;
     justify-content: flex-start;

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -50,10 +50,6 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
 </%static:require_module_async>
 
 <%block name="js_extra">
-  ## CourseTalk widget js script
-  % if show_coursetalk_widget:
-      <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-write-reviews.js"></script>
-  % endif
   % if user.is_authenticated() and user.is_active:
   <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
   <script type="text/javascript" charset="utf-8">

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -91,7 +91,7 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
         % endif
         % if user.is_authenticated() and user.is_active:
             <div class="page-header-secondary">
-                <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
+                <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
                     ${_("Copy Referral Link")}
                 </a>
             </div>

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -51,17 +51,17 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
 
 <%block name="js_extra">
   % if user.is_authenticated() and user.is_active:
-  <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
-  <script type="text/javascript" charset="utf-8">
-      $(document).ready(function () {
-          var domain_address = document.location.origin;
-          $.post(domain_address + "/api/get_referral_hash_key/", {},
-              function (data) {
-                  $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
+      <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
+      <script type="text/javascript" charset="utf-8">
+          $(document).ready(function () {
+              var domain_address = document.location.origin;
+              $.post(domain_address + "/api/get_referral_hash_key/", {},
+                  function (data) {
+                      $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
+              });
+              new Clipboard('.referral-btn');
           });
-          new Clipboard('.referral-btn');
-      });
-  </script>
+      </script>
   % endif
 </%block>
 

--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -49,6 +49,26 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
         CourseHomeEvents();
 </%static:require_module_async>
 
+<%block name="js_extra">
+  ## CourseTalk widget js script
+  % if show_coursetalk_widget:
+      <script src="//d3q6qq2zt8nhwv.cloudfront.net/s/js/widgets/coursetalk-write-reviews.js"></script>
+  % endif
+  % if user.is_authenticated() and user.is_active:
+  <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
+  <script type="text/javascript" charset="utf-8">
+      $(document).ready(function () {
+          var domain_address = document.location.origin;
+          $.post(domain_address + "/api/get_referral_hash_key/", {},
+              function (data) {
+                  $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
+          });
+          new Clipboard('.referral-btn');
+      });
+  </script>
+  % endif
+</%block>
+
 <%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">
@@ -68,6 +88,13 @@ from openedx.features.course_experience import SHOW_REVIEWS_TOOL_FLAG
           <div class="page-header-secondary">
               <a href="${resume_course_url}" class="last-accessed-link">${_("Resume Course")}</a>
           </div>
+        % endif
+        % if user.is_authenticated() and user.is_active:
+            <div class="page-header-secondary">
+                <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
+                    ${_("Copy Referral Link")}
+                </a>
+            </div>
         % endif
       </div>
       <div class="info-wrapper">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -54,6 +54,21 @@ from openedx.core.djangolib.markup import HTML, Text
         banner.showMessage(${redirect_message | n, dump_js_escaped_json})
     </%static:require_module>
   % endif
+
+  % if user.is_authenticated() and user.is_active:
+      <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
+      <script type="text/javascript" charset="utf-8">
+          $(document).ready(function () {
+              var domain_address = document.location.origin;
+              $.post(domain_address + "/api/get_referral_hash_key/", {},
+                  function (data) {
+                      $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
+              });
+              new Clipboard('.referral-btn');
+          });
+      </script>
+  % endif
+
 </%block>
 
 <div class="dashboard-notifications" tabindex="-1">
@@ -155,6 +170,14 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="sidebar-notification">
           ${sidebar_account_activation_message | n, decode.utf8}
         </div>
+      %endif
+
+      % if user.is_authenticated() and user.is_active:
+      <div class="page-header-secondary">
+          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
+              ${_("Copy Referral Link")}
+          </a>
+      </div>
       %endif
 
       % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -109,11 +109,11 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="container dashboard" id="dashboard-main">
 
       % if user.is_authenticated() and user.is_active:
-      <div class="referral-btn-wrapper">
-          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
-              ${_("Copy Referral Link")}
-          </a>
-      </div>
+          <div class="referral-btn-wrapper">
+              <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
+                  ${_("Copy Referral Link")}
+              </a>
+          </div>
       %endif
 
       <div class="my-courses" id="my-courses">

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -109,7 +109,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <div class="container dashboard" id="dashboard-main">
 
       % if user.is_authenticated() and user.is_active:
-      <div class="page-header-secondary">
+      <div class="referral-btn-wrapper">
           <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
               ${_("Copy Referral Link")}
           </a>

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -107,6 +107,15 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <div class="container dashboard" id="dashboard-main">
+
+      % if user.is_authenticated() and user.is_active:
+      <div class="page-header-secondary">
+          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
+              ${_("Copy Referral Link")}
+          </a>
+      </div>
+      %endif
+
       <div class="my-courses" id="my-courses">
         <%include file="learner_dashboard/_dashboard_navigation_courses.html"/>
 
@@ -170,14 +179,6 @@ from openedx.core.djangolib.markup import HTML, Text
         <div class="sidebar-notification">
           ${sidebar_account_activation_message | n, decode.utf8}
         </div>
-      %endif
-
-      % if user.is_authenticated() and user.is_active:
-      <div class="page-header-secondary">
-          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
-              ${_("Copy Referral Link")}
-          </a>
-      </div>
       %endif
 
       % if settings.FEATURES.get('ENABLE_DASHBOARD_SEARCH'):

--- a/lms/templates/dashboard.html
+++ b/lms/templates/dashboard.html
@@ -110,7 +110,7 @@ from openedx.core.djangolib.markup import HTML, Text
 
       % if user.is_authenticated() and user.is_active:
       <div class="referral-btn-wrapper">
-          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="Just because you can doesn't mean you should — clipboard.js">
+          <a href="#" class="referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
               ${_("Copy Referral Link")}
           </a>
       </div>


### PR DESCRIPTION
https://youtrack.raccoongang.com/issue/SKILLONOMY-95

p.68 in the doc attached to the Youtrack task

> "Пропала реферальная ссылка пользователя
не нашел реф ссылку на всех страницах в lms
до подключения шаблона, реф. ссылка была под авторизованным пользователем на странице /courses
нужно отображать ее на странице /courses
здесь: http://prntscr.com/nzowe0

Upd:
> на странице /courses не был предусмотрен элемент "Copy Referral Link" - он был добавлен только на /dashboard и на странице конкретного курса /info

Upd2:
> https://raccoongang.slack.com/archives/CDQ7E16RX/p1560270156124900

Dashboard:

<img width="732" alt="Screenshot 2019-06-12 00 08 31" src="https://user-images.githubusercontent.com/10282462/59307105-6d6f9600-8ca6-11e9-9160-f42205ed12e2.png">


Course info:

![Screenshot 2019-06-11 19 05 58](https://user-images.githubusercontent.com/10282462/59307119-76606780-8ca6-11e9-83df-9e3fc2f39947.png)
