### PR TITLE
SKILLONOMY-95 (p.61): Fix promo text 

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -25,7 +25,7 @@
       <h2 class="tree-blocks__heading">Преподаватели-практики</h2>
       <div class="tree-blocks__wrapper">
         <span class="tree-blocks__ico1"></span>
-        <p class="tree-blocks__text">Практикующие гуру готовы поделиться знаниями, в основе которых - успешный кейсы создания и развития рекламных кампаний.</p>
+        <p class="tree-blocks__text">Практикующие гуру готовы поделиться знаниями, в основе которых - успешные кейсы создания и развития рекламных кампаний.</p>
       </div>
     </div>
     <div class="tree-blocks__holder">


### PR DESCRIPTION
https://youtrack.raccoongang.com/issue/SKILLONOMY-95

p.61:
```
На главной странице орфографическая ошибка в тексте, "успешный" а нужно "успешные" 
```
