### PR TITLE
LSE-47 If a user shares a tweet about a course, the placeholder of a platform twitter account is displayed.

### DIFF
--- a/lms/templates/courseware/course_about_sidebar_header.html
+++ b/lms/templates/courseware/course_about_sidebar_header.html
@@ -19,10 +19,9 @@ import urllib
 
         ## Translators: This text will be automatically posted to the student's
         ## Twitter account. {url} should appear at the end of the text.
-        tweet_text = _("I just enrolled in {number} {title} through {account}: {url}").format(
+        tweet_text = _("I just enrolled in {number} {title} through: {url}").format(
             number=course.number,
             title=course.display_name_with_default_escaped,
-            account=static.get_value('course_about_twitter_account', settings.PLATFORM_TWITTER_ACCOUNT),
             url=u"http://{domain}{path}".format(
                 domain=site_domain,
                 path=reverse('about_course', args=[course.id.to_deprecated_string()])


### PR DESCRIPTION
**Description**
If a user shares a tweet about a course, the placeholder of a platform twitter account is displayed.
**Youtrack** [LSE-47](https://youtrack.raccoongang.com/issue/LSE-47)

**Steps to reproduce**

1. Open any course /about
2. click on twitter icon