### PR TITLE
Remove shopping cart, and change links

### DIFF
--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -40,11 +40,6 @@ from django.utils.translation import ugettext as _
   </ul>
 
   <ul class="navbar-nav navbar-right">
-    % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
-      <a role="button" class="nav-item-open-collapsed btn-shopping-cart btn btn-secondary mr-3" href="${reverse('shoppingcart.views.show_cart')}">
-        <span class="icon fa fa-shopping-cart" aria-hidden="true"></span> ${_("Shopping Cart")}
-      </a>
-    % endif
 
     <li class="nav-item mt-2 nav-item-open-collapsed">
       <a href="${get_online_help_info(online_help_token)['doc_url']}"

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -38,13 +38,6 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
         <a href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
       </li>
     %endif
-    % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
-      <li class="primary">
-        <a class="shopping-cart" href="${reverse('shoppingcart.views.show_cart')}">
-          <span class="icon fa fa-shopping-cart" aria-hidden="true"></span> ${_("Shopping Cart")}
-        </a>
-      </li>
-    % endif
   </%block>
 </ol>
 

--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -31,7 +31,7 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
     % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
       % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
         <li class="item nav-global-01">
-          <a href="/courses">${_("Explore Courses")}</a>
+          <a href="https://calypsoedu.com/shop">${_("Explore Courses")}</a>
         </li>
       %endif
     % endif


### PR DESCRIPTION
Hello, I work for Calypso Continuing Education.

I'm currently trying to remove the ability for the user to shop for courses, since they should do that on our site.

This PR changes the "Explore Courses" link on the navbar and removes the shopping cart.
