### PR TITLE
[ACCEL] Fix fetching masquerade role

### DIFF
--- a/lms/templates/course_experience/course-outline-fragment.html
+++ b/lms/templates/course_experience/course-outline-fragment.html
@@ -27,7 +27,7 @@ course_sections = blocks.get('children')
 
         if not request.session['masquerade_settings'] and not course_key:
             viewing_role = 'staff'
-        else:
+        elif course_key in request.session['masquerade_settings']:
             viewing_role = request.session['masquerade_settings'][course_key].role
 %>
 

--- a/lms/templates/course_experience/course-outline-fragment.html
+++ b/lms/templates/course_experience/course-outline-fragment.html
@@ -27,7 +27,7 @@ course_sections = blocks.get('children')
 
         if not request.session['masquerade_settings'] and not course_key:
             viewing_role = 'staff'
-        elif course_key in request.session['masquerade_settings']:
+        elif request.session['masquerade_settings'] and course_key in request.session['masquerade_settings']:
             viewing_role = request.session['masquerade_settings'][course_key].role
 %>
 


### PR DESCRIPTION
Fix error with next stack trace 

```Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/views.py", line 507, in get
    return super(CourseTabView, self).get(request, course=course, page_context=page_context, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/web_fragments/views.py", line 26, in get
    fragment = self.render_to_fragment(request, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/features/course_experience/views/course_home.py", line 68, in render_to_fragment
    return home_fragment_view.render_to_fragment(request, course_id=course_id, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/features/course_experience/views/course_home.py", line 124, in render_to_fragment
    outline_fragment = CourseOutlineFragmentView().render_to_fragment(request, course_id=course_id, **kwargs)
  File "/edx/app/edxapp/edx-platform/openedx/features/course_experience/views/course_outline.py", line 62, in render_to_fragment
    html = render_to_string('course_experience/course-outline-fragment.html', context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/loader.py", line 68, in render_to_string
    return template.render(context, request)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/template/backends/django.py", line 66, in render
    return self.template.render(context)
  File "/edx/app/edxapp/edx-platform/common/djangoapps/edxmako/template.py", line 59, in render
    return self.mako_template.render_unicode(**context_dictionary)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/template.py", line 454, in render_unicode
    as_unicode=True)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 829, in _render
    **_kwargs_for_callable(callable_, data))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 864, in _render_context
    _exec_template(inherit, lclcontext, args=args, kwargs=kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/mako/runtime.py", line 890, in _exec_template
    callable_(context, *args, **kwargs)
  File "/tmp/mako_lms/-6974679412401427525/course_experience/course-outline-fragment.html.py", line 69, in render_body
    viewing_role = request.session['masquerade_settings'][course_key].role
KeyError: CourseLocator(u'Andrey', u'sacsad', u'2019', None, None)
``` 