### PR TITLE
Redirect for Enroll button SU-135

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -165,8 +165,20 @@ from openedx.core.lib.courses import course_image_url
               .format(course_name=course.display_number_with_default, price=course_price)}
           </a>
           <div id="register_error"></div>
-        %else:
-          <% 
+        %elif not user.is_authenticated() and not registered:
+          <%
+            if ecommerce_checkout:
+              reg_href = ecommerce_checkout_link
+            else:
+              reg_href="#"
+            if professional_mode:
+              href_class = "add-to-cart"
+            else:
+              href_class = "register"
+          %>
+            ${_("Please sign in to enroll this course")}
+          %else :
+          <%
             if ecommerce_checkout:
               reg_href = ecommerce_checkout_link
             else:


### PR DESCRIPTION
[Youtrack SU-135](https://youtrack.raccoongang.com/issue/SU-135)	
**Description:**
There was configured redirect for Sign In button in the header earlier by the customer's request.
The customer found out that a non-logged user can reach the Register page by clicking Enroll on the About page of the course.