### PR TITLE
SU-143 Changes from 01.10

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -240,7 +240,7 @@ from openedx.core.lib.courses import course_image_url
               %>
             <li class="important-dates-item">
               <span class="icon fa fa-calendar" aria-hidden="true"></span>
-              <p class="important-dates-item-title">${_("Classes Start")}</p>
+              <p class="important-dates-item-title">${_("Available From")}</p>
               % if isinstance(course_start_date, str):
                   <span class="important-dates-item-text start-date">${course_start_date}</span>
               % else:
@@ -260,7 +260,7 @@ from openedx.core.lib.courses import course_image_url
 
             <li class="important-dates-item">
                 <span class="icon fa fa-calendar" aria-hidden="true"></span>
-                <p class="important-dates-item-title">${_("Classes End")}</p>
+                <p class="important-dates-item-title">${_("Available From")}</p>
                   % if isinstance(course_end_date, str):
                       <span class="important-dates-item-text final-date">${course_end_date}</span>
                   % else:

--- a/lms/templates/navigation.html
+++ b/lms/templates/navigation.html
@@ -99,7 +99,7 @@ site_status_msg = get_site_status_msg(course_id)
                 </a>
               </li>
               <li class="tab-nav-item">
-                <a href="${marketing_link('COURSES')}">${_('Find Courses')}</a>
+                <a href="${marketing_link('COURSES')}">${_('Explore Courses')}</a>
               </li>
               <li class="tab-nav-item">
                 <a class="${'active ' if reverse('course_category_list') == request.path else ''}tab-nav-link" href="${reverse('course_category_list')}">
@@ -139,7 +139,6 @@ site_status_msg = get_site_status_msg(course_id)
           <svg><use xlink:href="#ico-help"></use></svg>
         </a>
       </div>
-      <a id="certificate-voucher">${_("Certificate Voucher")}</a>
       % if should_display_shopping_cart_func() and not (course and static.is_request_in_themed_site()): # see shoppingcart.context_processor.user_has_cart_context_processor
         <ol class="user">
           <li class="primary">
@@ -184,9 +183,6 @@ site_status_msg = get_site_status_msg(course_id)
       </ol>
 
       <ol class="right nav-courseware list-inline">
-        <li class="item additional">
-          <a id="certificate-voucher">${_("Certificate Voucher")}</a>
-        </li>
         <li class="help-center-link-wrapper">
           <a href="https://www.staffs.ac.uk/support_depts/digital-services/contactus.jsp" class="help-center-link" target="_blank" title="Help Center">
             <svg><use xlink:href="#ico-help"></use></svg>


### PR DESCRIPTION
[SU-143](https://youtrack.raccoongang.com/issue/SU-143) Changes from 01.10
- change wordings "Classes Start", "Classes End" to "Available From", "Available From" on the About course page
- make button Explore Courses not changed to Find Courses. This button should always appear as Explore courses (this is the default flow but was requested by the customer)
- remove "Certificate Voucher" button in the header