### PR TITLE
[CCTD-23] remove margin right in responsive for the wiki btns

### DIFF
--- a/lms/static/sass/base/_override.scss
+++ b/lms/static/sass/base/_override.scss
@@ -3311,6 +3311,10 @@ section.wiki .alert .close {
 
 section.wiki .btn {
     margin-bottom: 5px;
+
+    @media screen and (max-width: $breakpoint-mobile){
+        margin-right: 0 !important;
+    }
 }
 
 section.wiki .btn.btn-danger {


### PR DESCRIPTION
Fix margins on the wiki page for buttons in the responsive mode
https://youtrack.raccoongang.com/issue/CCTD-23