### PR TITLE
[PROFITONOMY-172] Remove table from course progress

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -128,7 +128,6 @@
       </section>
     %endif
   </div>
-  <iframe src="${reverse('learner_performance_progress', kwargs={'course_id': course.id, 'student_id':student.id})}" width="1140px" height="500"></iframe>
   <!--end-->
 </main>
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">


### PR DESCRIPTION
Hide learner_performance_progress table.
May be reversed in future.

**Youtrack** https://youtrack.raccoongang.com/issue/SKILLONOMY-172