### PR TITLE
[SKILLONOMY-201] Fix for View all courses button

### DIFF
--- a/lms/templates/courses_list.html
+++ b/lms/templates/courses_list.html
@@ -9,15 +9,16 @@
       <section class="courses course-page-section">
         <h2 class="h2">Курсы, которые скоро начнутся</h2>
         <ul class="courses-listing">
+          <% course_max = settings.HOMEPAGE_COURSE_MAX %>
           ## limiting the course number by using HOMEPAGE_COURSE_MAX as the maximum number of courses
-          %for course in courses[:settings.HOMEPAGE_COURSE_MAX]:
+          %for course in courses[:course_max]:
           <li class="courses-listing-item">
               <%include file="course.html" args="course=course" />
           </li>
-        %endfor
+          %endfor
         </ul>
         ## in case there are courses that are not shown on the homepage, a 'View all Courses' link should appear
-        % if settings.HOMEPAGE_COURSE_MAX and len(courses) > settings.HOMEPAGE_COURSE_MAX:
+        % if course_max and len([c for c in courses if not c.has_ended()]) > course_max:
         <div class="courses-more">
           <a class="courses-more-cta" href="${marketing_link('COURSES')}"> ${_("View all Courses")} </a>
         </div>


### PR DESCRIPTION
Courses that have already ended and not displayed on the main page excluded from the courses count.

https://youtrack.raccoongang.com/issue/SKILLONOMY-201