### PR TITLE
HERA-453 [LMS] hide table submission warning message

### DIFF
--- a/lms/templates/seq_module.html
+++ b/lms/templates/seq_module.html
@@ -83,7 +83,7 @@
 
   <div class="footer-controls" aria-label="${_('Section')}">
     <div class="footer-controls-buttons-holder">
-      <div class="js-show-hide-warning-message">
+      <div class="js-show-hide-warning-message" style="display: none;">
         ${_("It seems like you haven't fully interacted with the table. Give it another try. If you'd like to exit, press next again")}!
       </div>
       <div class="footer-controls-btns">


### PR DESCRIPTION
**Description:** block with `footer-controls-buttons-holder` class will be changed, this pr needs for correct functionality in Introduction/Simulation xblocks, [related pr in platform](https://github.com/raccoongang/edx-platform/pull/1853) which hides or shows message in block with class `js-show-hide-warning-message`

**Youtrack:** [ticket](https://youtrack.raccoongang.com/issue/HERA-453)