### PR TITLE
[GREENHOST-241] fix Image Mapped Input xblock for RTL direction

### DIFF
--- a/lms/static/sass/base/_override.scss
+++ b/lms/static/sass/base/_override.scss
@@ -1752,6 +1752,13 @@ div {
                     }
                 }
             }
+
+            .capa_inputtype.imageinput [id^="answer_"] {
+                .rtl & {
+                    left: auto;
+                    right: 0;
+                }
+            }
         }
 
         .wrapper-problem-response {


### PR DESCRIPTION
**Description:** fix "Image Mapped Input" xblock for RTL direction

**Youtrack:** https://youtrack.raccoongang.com/issue/GREENHOST-241