### PR TITLE
[ MAMA Skillonomy ] SKILLONOMY-229: Add Google Analytics scripts (global site tag)

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -154,6 +154,20 @@ from pipeline_mako import render_require_js_path_overrides
 <!-- /Yandex.Metrika counter -->
 % endif
 
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<% ga_measurement_id = static.get_value("GOOGLE_ANALYTICS_MEASUREMENT_ID", settings.GOOGLE_ANALYTICS_MEASUREMENT_ID) %>
+% if ga_measurement_id:
+    <script async src="https://www.googletagmanager.com/gtag/js?id=${ga_measurement_id}"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){
+      	dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', '${ga_measurement_id}');
+    </script>
+% endif
+
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">


### PR DESCRIPTION
**Description:** 

Add Google Analytics scripts to LMS.
(global site tag https://developers.google.com/analytics/devguides/collection/gtagjs)

**Youtrack:**

https://youtrack.raccoongang.com/issue/SKILLONOMY-229


**Merge deadline:** 

02 April

**Configuration instructions:** 

1pass, ticket.

Need to add "GOOGLE_ANALYTICS_MEASUREMENT_ID" to "lms.auth.json" on both STAGE and PROD

**Author concerns:**

- accompanying PR https://github.com/raccoongang/edx-platform/pull/1972
- didn't use `GOOGLE_ANALYTICS_ACCOUNT`; looks like a completely different story
- didn't introduce a  feature config "ENABLE_GA" or so: id presense is enough (just like "GOOGLE_ANALYTICS_ACCOUNT" is implemented). Ref. from edx platform README:
```
* If you don't want the Google Analytics JavaScript to be output at all in your
  site, set the "GOOGLE_ANALYTICS_ACCOUNT" config value to the empty string."
```