### PR TITLE
[ MAMA Skillonomy ] SKILLONOMY-229: Add Google Tag Manager / GA, remove GA global tag

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -154,23 +154,28 @@ from pipeline_mako import render_require_js_path_overrides
 <!-- /Yandex.Metrika counter -->
 % endif
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<% ga_measurement_id = static.get_value("GOOGLE_ANALYTICS_MEASUREMENT_ID", settings.GOOGLE_ANALYTICS_MEASUREMENT_ID) %>
-% if ga_measurement_id:
-    <script async src="https://www.googletagmanager.com/gtag/js?id=${ga_measurement_id}"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){
-      	dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
-      gtag('config', '${ga_measurement_id}');
-    </script>
+<% gtm_id = static.get_value("GOOGLE_TAG_MANAGER_ID", settings.GOOGLE_TAG_MANAGER_ID) %>
+% if gtm_id:
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','${gtm_id}');</script>
+    <!-- End Google Tag Manager -->
 % endif
 
 </head>
 
 <body class="${static.dir_rtl()} <%block name='bodyclass'/> lang_${LANGUAGE_CODE}">
+
+% if gtm_id:
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id='${gtm_id}'"
+                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+% endif
+
 <svg style="display: none">
     <symbol viewBox="0 0 1536 1536" id="ico-fs-expand">
         <path d="M1283 413L928 768l355 355 144-144q29-31 70-14 39 17 39 59v448q0 26-19 45t-45 19h-448q-42 0-59-40-17-39 14-69l144-144-355-355-355 355 144 144q31 30 14 69-17 40-59 40H64q-26 0-45-19t-19-45v-448q0-42 40-59 39-17 69 14l144 144 355-355-355-355-144 144q-19 19-45 19-12 0-24-5-40-17-40-59V64q0-26 19-45T64 0h448q42 0 59 40 17 39-14 69L413 253l355 355 355-355-144-144q-31-30-14-69 17-40 59-40h448q26 0 45 19t19 45v448q0 42-39 59-13 5-25 5-26 0-45-19z"></path>


### PR DESCRIPTION
Description: 

Move from GA global tag to GA Google Tag Manager (GTM).

Youtrack:

https://youtrack.raccoongang.com/issue/SKILLONOMY-229

Merge deadline:

- 03 April

Configuration instructions:

- 1pass, ticket

Author concerns:

- accompanying PR https://github.com/raccoongang/edx-platform/pull/1977
- decided not to introduce a new dependency (e.g. https://pypi.org/project/django-google-tag-manager/, https://pypi.org/project/django-gtm/0.1/ )