### PR TITLE
[HERA] STAGE SYNC 2020-04-15

### DIFF
--- a/lms/static/sass/blocks/_dashboard-hera.scss
+++ b/lms/static/sass/blocks/_dashboard-hera.scss
@@ -107,6 +107,10 @@
     }
 }
 
+.in-progress {
+    color: #e67312;
+}
+
 .hera-message {
     display: flex;
     align-items: center;


### PR DESCRIPTION
[HERA-627](https://youtrack.raccoongang.com/issue/HERA-627) - `8 lessons available and visible on the Dashboard`
[HERA-621](https://youtrack.raccoongang.com/issue/HERA-621) - `Simulation/iframe in Questions in the same window/not in modal window`
[HERA-620](https://youtrack.raccoongang.com/issue/HERA-620) - `Confidence error message display incorrect in mobile view`
[HERA-633](https://youtrack.raccoongang.com/issue/HERA-633) - `''Hide simulation" button covers the video controls panel`
[HERA-634](https://youtrack.raccoongang.com/issue/HERA-634) - `When user open scaffold w/o text and open scaffold w/o image, the "Show simulation" button doesn’t show`