### PR TITLE
[MAMAEdu-122909] Change course tabs access rules

### DIFF
--- a/lms/templates/courseware/info.html
+++ b/lms/templates/courseware/info.html
@@ -41,232 +41,234 @@ from courseware.courses import get_course_about_section
 </div>
 % endif
 
-<%include file="/courseware/course_navigation.html" args="active_page='info'" />
+% if not show_enroll_banner or staff_access:
+  <%include file="/courseware/course_navigation.html" args="active_page='info'" />
 
-<%static:require_module_async module_name="js/courseware/toggle_element_visibility" class_name="ToggleElementVisibility">
-        ToggleElementVisibility();
-</%static:require_module_async>
-<%static:require_module_async module_name="js/courseware/course_home_events" class_name="CourseHomeEvents">
-        CourseHomeEvents();
-</%static:require_module_async>
+  <%static:require_module_async module_name="js/courseware/toggle_element_visibility" class_name="ToggleElementVisibility">
+          ToggleElementVisibility();
+  </%static:require_module_async>
+  <%static:require_module_async module_name="js/courseware/course_home_events" class_name="CourseHomeEvents">
+          CourseHomeEvents();
+  </%static:require_module_async>
 
-<%block name="js_extra">
-  % if user.is_authenticated() and user.is_active:
-      <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
-      <script type="text/javascript" charset="utf-8">
-          $(document).ready(function () {
-              var domain_address = document.location.origin;
-              $.post(domain_address + "/api/get_referral_hash_key/", {},
-                  function (data) {
-                      $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
-              });
-              new Clipboard('.referral-btn');
-          });
-      </script>
-  % endif
-</%block>
+  <%block name="js_extra">
+    % if user.is_authenticated() and user.is_active:
+        <script src="https://cdn.jsdelivr.net/clipboard.js/1.6.0/clipboard.min.js"></script>
+        <script type="text/javascript" charset="utf-8">
+            $(document).ready(function () {
+                var domain_address = document.location.origin;
+                $.post(domain_address + "/api/get_referral_hash_key/", {},
+                    function (data) {
+                        $(".referral-btn").attr('data-clipboard-text', (domain_address + data.hashkey));
+                });
+                new Clipboard('.referral-btn');
+            });
+        </script>
+    % endif
+  </%block>
 
-<%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
+  <%block name="bodyclass">view-in-course view-course-info ${course.css_class or ''}</%block>
 
-<main id="main" aria-label="Content" tabindex="-1">
-    <div class="container"
-      % if getattr(course, 'language'):
-        lang="${course.language}"
-      % endif
-      >
-      <div class="info-wrapper">
-        % if user.is_authenticated():
-          <section class="updates">
-            % if (studio_url is not None and masquerade and masquerade.role == 'staff') or user.is_staff:
-              <div class="wrap-instructor-info studio-view">
-                <a class="instructor-info-action" href="${studio_url}">
-                  ${_("View Updates in Studio")}
-                </a>
-              </div>
-            % endif
-          </section>
-          <div class="week_holder">
-            <div class="week-structure-container">
-              <h3 class="h3 week_holder__title">Программа курса</h3>
-              % if blocks.get('children'):
-                % for section in blocks.get('children'):
-                <section class="week-structure">
-                    <div class="week-structure__name">
-                      <span class="week-structure__ico"></span>
-                      <strong>${ section['display_name'] }</strong>
-                    </div>
-                    <div class="week-structure__box">
-                        <ul class="week-structure__list">
-                          % for subsection in section.get('children', []):
-                            <%
-                            is_checked = ''
-                            if subsection['last_accessed']:
-                              is_checked = 'is-checked'
-                            %>
-                            <li class="week-structure__list-item">
-                                <div class="week-structure__helper ${is_checked}"></div>
-                                <a
-                                class="outline-item focusable"
-                                href="${ subsection['lms_web_url'] }"
-                                id="${ subsection['id'] }"
-                              >
-                              ${ subsection['display_name'] }</a>
-                            </li>
-                          % endfor
-                        </ul>
-                    </div>
-                </section>
-                % endfor
-            % endif
-          </div>
-          </div>
-          <section aria-label="${_('Handout Navigation')}" class="handouts">
-            <h3 class="hd hd-3 handouts-header">${_("Course Tools")}</h3>
-              <div>
-                  <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
-                      <span class="icon fa fa-bookmark" aria-hidden="true"></span>
-                      ${_("Bookmarks")}
+  <main id="main" aria-label="Content" tabindex="-1">
+      <div class="container"
+        % if getattr(course, 'language'):
+          lang="${course.language}"
+        % endif
+        >
+        <div class="info-wrapper">
+          % if user.is_authenticated():
+            <section class="updates">
+              % if (studio_url is not None and masquerade and masquerade.role == 'staff') or user.is_staff:
+                <div class="wrap-instructor-info studio-view">
+                  <a class="instructor-info-action" href="${studio_url}">
+                    ${_("View Updates in Studio")}
                   </a>
-                  % if SHOW_REVIEWS_TOOL_FLAG.is_enabled(course.id) and show_reviews_link:
-                      <a href="${reverse('openedx.course_experience.course_reviews', args=[course.id])}">
-                          <span class="icon fa fa-star" aria-hidden="true"></span>
-                          ${_("Reviews")}
-                      </a>
-                  % endif
-              </div>
-
-            % if SelfPacedConfiguration.current().enable_course_home_improvements:
-              ${HTML(dates_fragment.body_html())}
-            % endif
-              <h3 class="hd hd-3  handouts-header">${_(course.info_sidebar_name)}</h3>
-              ${HTML(get_course_info_section(request, masquerade_user, course, 'handouts'))}
-          </section>
-        % else:
-          <section class="updates">
-            <h3 class="hd hd-3 handouts-header">${_("Course Updates and News")}</h3>
-            ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_updates'))}
-          </section>
-          <section aria-label="${_('Handout Navigation')}" class="handouts">
-            <h3 class="hd hd-3 handouts-header">${_("Course Handouts")}</h3>
-            ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_handouts'))}
-          </section>
-        % endif <!-- if course authenticated -->
-      </div>
-      <div class="home">
-        <div class="course-review-section">
-          <h2 class="course-review-section__title">ОБЗОР КУРСА</h2>
-          <div class="course-review-section__container">
-            <ul class="course-review-list">
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Дата старта курса</div>
-                <% course_start = course.start.strftime('%d %b. %Y') %>
-                <div class="course-review-list__text">${course_start}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Язык курса</div>
-                <div class="course-review-list__text">${_(course.language)}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Нагрузка в неделю</div>
-                % if get_course_about_section(request, course, 'effort'):
-                  <%
-                  effort = get_course_about_section(request, course, 'effort').split(':')[0].strip()
-                  if effort[0] == '0':
-                    effort = effort[1]
-                  %>
-                  <div class="course-review-list__text">
-                    ${effort} ${ungettext("Hour per week", "Hours per week", int(effort))}
-                  </div>
-                % else:
-                  <div class="course-review-list__text">Не доступно</div>
-                % endif
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Домашние задания</div>
-                <div class="course-review-list__text">${course.number_of_homeworks}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Время занятий</div>
-                <%
-                class_time = 'Не доступно'
-                if get_course_about_section(request, course, 'class_time'):
-                  class_time = get_course_about_section(request, course, 'class_time')
-                %>
-                <div class="course-review-list__text">${class_time}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Количество видео</div>
-                <div class="course-review-list__text">${course.number_of_videos}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Время прохождения курса</div>
-                % if course_duration:
-                  <div class="course-review-list__text">
-                    ${course_duration} ${ungettext("Week", "Weeks", course_duration)}
-                  </div>
-                % else:
-                  <div class="course-review-list__text">
-                    Не доступно
-                  </div>
-                % endif
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Лекций</div>
-                <div class="course-review-list__text">${course.number_of_lections}</div>
-              </li>
-              <li class="course-review-list__item">
-                <div class="course-review-list__title">Тесты</div>
-                <div class="course-review-list__text">${course.number_of_tests}</div>
-              </li>
-            </ul>
-            <div class="course-review-info">
-              <ul>
-                <li>
-                  <a href="${course.telegram_chat_link}" target="_blank">
-                    <svg class="svg-icon" viewBox="0 0 24 24">
-                      <use xlink:href="#fa-brands_telegram"></use>
-                    </svg>
-                    <span>${_("@Chat")}</span>
-                  </a>
-                </li>
-                <li>
-                  % if resume_course_url and user_is_enrolled:
-                    <div class="page-header-secondary">
-                        <a href="${resume_course_url}" class="last-accessed-link js-referral-btn">
-                          <svg class="svg-icon" viewBox="0 0 24 24">
-                            <use xlink:href="#referal-link"></use>
-                          </svg>
-                          <svg class="svg-icon svg-icon_done" viewBox="0 0 24 24">
-                            <use xlink:href="#referal-link-done"></use>
-                          </svg>
-                          <span class="tooltip-info" data-tooltip-before="скопировать" data-tooltip-after="скопированно">${_("Resume Course")}</span>
-                        </a>
-                    </div>
-                  % endif
-                  % if user.is_authenticated() and user.is_active:
-                      <div class="page-header-secondary">
-                          <a href="javascript:;" class="referral-btn js-referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
-                              <svg class="svg-icon" viewBox="0 0 24 24">
-                                <use xlink:href="#referal-link"></use>
-                              </svg>
-                              <svg class="svg-icon svg-icon_done" viewBox="0 0 24 24">
-                                <use xlink:href="#referal-link-done"></use>
-                              </svg>
-                              <span class="tooltip-info" data-tooltip-before="скопировать" data-tooltip-after="скопированно">${_("Copy Referral Link")}</span>
-                          </a>
+                </div>
+              % endif
+            </section>
+            <div class="week_holder">
+              <div class="week-structure-container">
+                <h3 class="h3 week_holder__title">Программа курса</h3>
+                % if blocks.get('children'):
+                  % for section in blocks.get('children'):
+                  <section class="week-structure">
+                      <div class="week-structure__name">
+                        <span class="week-structure__ico"></span>
+                        <strong>${ section['display_name'] }</strong>
                       </div>
+                      <div class="week-structure__box">
+                          <ul class="week-structure__list">
+                            % for subsection in section.get('children', []):
+                              <%
+                              is_checked = ''
+                              if subsection['last_accessed']:
+                                is_checked = 'is-checked'
+                              %>
+                              <li class="week-structure__list-item">
+                                  <div class="week-structure__helper ${is_checked}"></div>
+                                  <a
+                                  class="outline-item focusable"
+                                  href="${ subsection['lms_web_url'] }"
+                                  id="${ subsection['id'] }"
+                                >
+                                ${ subsection['display_name'] }</a>
+                              </li>
+                            % endfor
+                          </ul>
+                      </div>
+                  </section>
+                  % endfor
+              % endif
+            </div>
+            </div>
+            <section aria-label="${_('Handout Navigation')}" class="handouts">
+              <h3 class="hd hd-3 handouts-header">${_("Course Tools")}</h3>
+                <div>
+                    <a class="action-show-bookmarks" href="${reverse('openedx.course_bookmarks.home', args=[course.id])}">
+                        <span class="icon fa fa-bookmark" aria-hidden="true"></span>
+                        ${_("Bookmarks")}
+                    </a>
+                    % if SHOW_REVIEWS_TOOL_FLAG.is_enabled(course.id) and show_reviews_link:
+                        <a href="${reverse('openedx.course_experience.course_reviews', args=[course.id])}">
+                            <span class="icon fa fa-star" aria-hidden="true"></span>
+                            ${_("Reviews")}
+                        </a>
+                    % endif
+                </div>
+
+              % if SelfPacedConfiguration.current().enable_course_home_improvements:
+                ${HTML(dates_fragment.body_html())}
+              % endif
+                <h3 class="hd hd-3  handouts-header">${_(course.info_sidebar_name)}</h3>
+                ${HTML(get_course_info_section(request, masquerade_user, course, 'handouts'))}
+            </section>
+          % else:
+            <section class="updates">
+              <h3 class="hd hd-3 handouts-header">${_("Course Updates and News")}</h3>
+              ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_updates'))}
+            </section>
+            <section aria-label="${_('Handout Navigation')}" class="handouts">
+              <h3 class="hd hd-3 handouts-header">${_("Course Handouts")}</h3>
+              ${HTML(get_course_info_section(request, masquerade_user, course, 'guest_handouts'))}
+            </section>
+          % endif <!-- if course authenticated -->
+        </div>
+        <div class="home">
+          <div class="course-review-section">
+            <h2 class="course-review-section__title">ОБЗОР КУРСА</h2>
+            <div class="course-review-section__container">
+              <ul class="course-review-list">
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Дата старта курса</div>
+                  <% course_start = course.start.strftime('%d %b. %Y') %>
+                  <div class="course-review-list__text">${course_start}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Язык курса</div>
+                  <div class="course-review-list__text">${_(course.language)}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Нагрузка в неделю</div>
+                  % if get_course_about_section(request, course, 'effort'):
+                    <%
+                    effort = get_course_about_section(request, course, 'effort').split(':')[0].strip()
+                    if effort[0] == '0':
+                      effort = effort[1]
+                    %>
+                    <div class="course-review-list__text">
+                      ${effort} ${ungettext("Hour per week", "Hours per week", int(effort))}
+                    </div>
+                  % else:
+                    <div class="course-review-list__text">Не доступно</div>
                   % endif
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Домашние задания</div>
+                  <div class="course-review-list__text">${course.number_of_homeworks}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Время занятий</div>
+                  <%
+                  class_time = 'Не доступно'
+                  if get_course_about_section(request, course, 'class_time'):
+                    class_time = get_course_about_section(request, course, 'class_time')
+                  %>
+                  <div class="course-review-list__text">${class_time}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Количество видео</div>
+                  <div class="course-review-list__text">${course.number_of_videos}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Время прохождения курса</div>
+                  % if course_duration:
+                    <div class="course-review-list__text">
+                      ${course_duration} ${ungettext("Week", "Weeks", course_duration)}
+                    </div>
+                  % else:
+                    <div class="course-review-list__text">
+                      Не доступно
+                    </div>
+                  % endif
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Лекций</div>
+                  <div class="course-review-list__text">${course.number_of_lections}</div>
+                </li>
+                <li class="course-review-list__item">
+                  <div class="course-review-list__title">Тесты</div>
+                  <div class="course-review-list__text">${course.number_of_tests}</div>
                 </li>
               </ul>
+              <div class="course-review-info">
+                <ul>
+                  <li>
+                    <a href="${course.telegram_chat_link}" target="_blank">
+                      <svg class="svg-icon" viewBox="0 0 24 24">
+                        <use xlink:href="#fa-brands_telegram"></use>
+                      </svg>
+                      <span>${_("@Chat")}</span>
+                    </a>
+                  </li>
+                  <li>
+                    % if resume_course_url and user_is_enrolled:
+                      <div class="page-header-secondary">
+                          <a href="${resume_course_url}" class="last-accessed-link js-referral-btn">
+                            <svg class="svg-icon" viewBox="0 0 24 24">
+                              <use xlink:href="#referal-link"></use>
+                            </svg>
+                            <svg class="svg-icon svg-icon_done" viewBox="0 0 24 24">
+                              <use xlink:href="#referal-link-done"></use>
+                            </svg>
+                            <span class="tooltip-info" data-tooltip-before="скопировать" data-tooltip-after="скопированно">${_("Resume Course")}</span>
+                          </a>
+                      </div>
+                    % endif
+                    % if user.is_authenticated() and user.is_active:
+                        <div class="page-header-secondary">
+                            <a href="javascript:;" class="referral-btn js-referral-btn last-accessed-link" data-clipboard-text="An error happened while fetching the referral link from the backend.">
+                                <svg class="svg-icon" viewBox="0 0 24 24">
+                                  <use xlink:href="#referal-link"></use>
+                                </svg>
+                                <svg class="svg-icon svg-icon_done" viewBox="0 0 24 24">
+                                  <use xlink:href="#referal-link-done"></use>
+                                </svg>
+                                <span class="tooltip-info" data-tooltip-before="скопировать" data-tooltip-after="скопированно">${_("Copy Referral Link")}</span>
+                            </a>
+                        </div>
+                    % endif
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
+          % if get_course_about_section(request, course, "overview_teacher"):
+            ${get_course_about_section(request, course, "overview_teacher") | n}
+          % endif
         </div>
-        % if get_course_about_section(request, course, "overview_teacher"):
-          ${get_course_about_section(request, course, "overview_teacher") | n}
-        % endif
-      </div>
-  </div>
-</main>
+    </div>
+  </main>
+% endif
 
 <%static:require_module_async module_name="js/dateutil_factory" class_name="DateUtilFactory">
     DateUtilFactory.transform(iterationKey=".localized-datetime");

--- a/lms/templates/courseware/static_tab.html
+++ b/lms/templates/courseware/static_tab.html
@@ -1,0 +1,59 @@
+## mako
+
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+
+<%inherit file="/main.html" />
+<%block name="bodyclass">view-in-course view-statictab ${course.css_class or ''}</%block>
+<%namespace name='static' file='/static_content.html'/>
+
+<%block name="head_extra">
+<%static:css group='style-course-vendor'/>
+<%static:css group='style-course'/>
+${HTML(fragment.head_html())}
+</%block>
+
+<%block name="footer_extra">
+<%include file="/mathjax_include.html" args="disable_fast_preview=True"/>
+${HTML(fragment.foot_html())}
+</%block>
+
+<%block name="pagetitle">${tab['name']} | ${course.display_number_with_default}</%block>
+
+% if show_enroll_banner:
+<div class="wrapper-msg urgency-low" id="failed-verification-banner">
+  <div class="msg msg-reverify is-dismissable">
+    <div class="msg-content">
+      <h2 class="title">${_("You are not enrolled yet")}</h2>
+      <div class="copy">
+        <p class='enroll-message'>
+          ${Text(_("You are not currently enrolled in this course. {link_start}Enroll now!{link_end}")).format(
+                link_start=HTML("<a href={}>").format(url_to_enroll),
+                link_end=HTML("</a>")
+          )}
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+% endif
+
+% if not show_enroll_banner or staff_access:
+  <%include file="/courseware/course_navigation.html" args="active_page=active_page" />
+
+    <main id="main" aria-label="Content" tabindex="-1">
+        <section class="container"
+        % if getattr(course, 'language'):
+          lang=${course.language}
+        % endif
+        >
+        <section class="container">
+          <div class="static_tab_wrapper">
+            ${HTML(fragment.body_html())}
+          </div>
+        </section>
+    </main>
+% endif


### PR DESCRIPTION
**Youtrack:**
- https://youtrack.raccoongang.com/issue/MAMAEdu-122909

Changes:
- redirect to login page from /info or static tab if user is anonymous
- add banner for users without enrollment to course
- hide page content for users without enrollment
- add/update templates for /info & static tab

**Post merge:**
- [ ] Delete working branch (if not needed anymore)

Relates to:
- https://github.com/raccoongang/edx-platform/pull/2254